### PR TITLE
Detect server disconnection during subscribe (#33)

### DIFF
--- a/Redis.cpp
+++ b/Redis.cpp
@@ -156,6 +156,16 @@ RedisSubscribeResult Redis::startSubscribing(RedisMsgCallback messageCallback, R
     while (subLoopRun) {
         auto msg = RedisObject::parseType(conn);
 
+        if (msg->type() == RedisObject::Type::InternalError) {
+          auto errPtr = (RedisInternalError*)msg.get();
+
+          if (errPtr->code() == RedisInternalError::Disconnected) {
+            return RedisSubscribeServerDisconnected;
+          }
+
+          return RedisSubscribeOtherError;
+        }
+
         if (msg->type() != RedisObject::Type::Array) {
             emitErr(RedisMessageBadResponseType);
             continue;

--- a/Redis.h
+++ b/Redis.h
@@ -35,6 +35,8 @@ typedef enum {
 typedef enum {
   RedisSubscribeBadCallback = -255,
   RedisSubscribeSetupFailure,
+  RedisSubscribeServerDisconnected,
+  RedisSubscribeOtherError,
   RedisSubscribeSuccess = 0
 } RedisSubscribeResult;
 

--- a/examples/Subscribe/Subscribe.ino
+++ b/examples/Subscribe/Subscribe.ino
@@ -48,7 +48,7 @@ void setup()
             ++backoffCounter;
         }
 
-        Serial.printf("Waiting %ld s to reconnect...\n", (backoffCounter + 1) / 1000, curDelay);
+        Serial.printf("Waiting %lds to reconnect...\n", curDelay / 1000);
         delay(curDelay);
     }
 

--- a/examples/Subscribe/Subscribe.ino
+++ b/examples/Subscribe/Subscribe.ino
@@ -39,9 +39,15 @@ void setup()
     auto backoffCounter = -1;
     auto resetBackoffCounter = [&]() { backoffCounter = 0; };
 
-    for (resetBackoffCounter(); subscriberLoop(resetBackoffCounter); backoffCounter++)
+    resetBackoffCounter();
+    while (subscriberLoop(resetBackoffCounter))
     {
         auto curDelay = min((1000 * (int)pow(2, backoffCounter)), MAX_BACKOFF);
+
+        if (curDelay != MAX_BACKOFF) {
+            ++backoffCounter;
+        }
+
         Serial.printf("retry #%d, waiting %ld ms...\n", backoffCounter + 1, curDelay);
         delay(curDelay);
     }

--- a/examples/Subscribe/Subscribe.ino
+++ b/examples/Subscribe/Subscribe.ino
@@ -48,7 +48,7 @@ void setup()
             ++backoffCounter;
         }
 
-        Serial.printf("retry #%d, waiting %ld ms...\n", backoffCounter + 1, curDelay);
+        Serial.printf("Waiting %ld s to reconnect...\n", (backoffCounter + 1) / 1000, curDelay);
         delay(curDelay);
     }
 

--- a/examples/Subscribe/Subscribe.ino
+++ b/examples/Subscribe/Subscribe.ino
@@ -10,14 +10,16 @@
 #endif
 #endif
 
-#define WIFI_SSID       ""
-#define WIFI_PASSWORD   ""
+#define WIFI_SSID ""
+#define WIFI_PASSWORD ""
 
-#define REDIS_ADDR      "0.0.0.0"
-#define REDIS_PORT      6379
-#define REDIS_PASSWORD  "password"
+#define REDIS_ADDR "0.0.0.0"
+#define REDIS_PORT 6379
+#define REDIS_PASSWORD "password"
 
-void setup() 
+#define MAX_BACKOFF 300000 // 5 minutes
+
+void setup()
 {
     Serial.begin(115200);
     Serial.println();
@@ -25,7 +27,7 @@ void setup()
     WiFi.mode(WIFI_STA);
     WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
     Serial.print("Connecting to the WiFi");
-    while (WiFi.status() != WL_CONNECTED) 
+    while (WiFi.status() != WL_CONNECTED)
     {
         delay(250);
         Serial.print(".");
@@ -34,11 +36,27 @@ void setup()
     Serial.print("IP Address: ");
     Serial.println(WiFi.localIP());
 
+    auto backoffCounter = -1;
+    auto resetBackoffCounter = [&]() { backoffCounter = 0; };
+
+    for (resetBackoffCounter(); subscriberLoop(resetBackoffCounter); backoffCounter++)
+    {
+        auto curDelay = min((1000 * (int)pow(2, backoffCounter)), MAX_BACKOFF);
+        Serial.printf("retry #%d, waiting %ld ms...\n", backoffCounter + 1, curDelay);
+        delay(curDelay);
+    }
+
+    Serial.printf("Done!\n");
+}
+
+// returning 'true' indicates the failure was retryable; false is fatal
+bool subscriberLoop(std::function<void(void)> resetBackoffCounter)
+{
     WiFiClient redisConn;
     if (!redisConn.connect(REDIS_ADDR, REDIS_PORT))
     {
         Serial.println("Failed to connect to the Redis server!");
-        return;
+        return true;
     }
 
     Redis redis(redisConn);
@@ -46,11 +64,11 @@ void setup()
     if (connRet == RedisSuccess)
     {
         Serial.println("Connected to the Redis server!");
-    } 
-    else 
+    }
+    else
     {
         Serial.printf("Failed to authenticate to the Redis server! Errno: %d\n", (int)connRet);
-        return;
+        return false;
     }
 
     redis.subscribe("foo");
@@ -59,48 +77,43 @@ void setup()
     redis.psubscribe("ctrl-*");
 
     Serial.println("Listening...");
+    resetBackoffCounter();
 
     auto subRv = redis.startSubscribing(
-      [=](Redis* redisInst, String channel, String msg) 
-      {
-        Serial.printf("Message on channel '%s': \"%s\"\n", channel.c_str(), msg.c_str());
-      
-        if (channel == "ctrl-close")
-        {
-          Serial.println("Got message on ctrl-close: ending!");
-          redisInst->stopSubscribing();
-        } else if (channel == "ctrl-add")
-        {
-          Serial.printf("Adding subscription to channel '%s'\n", msg.c_str());
+        [=](Redis *redisInst, String channel, String msg) {
+            Serial.printf("Message on channel '%s': \"%s\"\n", channel.c_str(), msg.c_str());
 
-          if (!redisInst->subscribe(msg.c_str()))
-          {
-            Serial.println("Failed to add subscription!");
-          }
-        } else if (channel == "ctrl-rm")
-        {
-          Serial.printf("Removing subscription to channel '%s'\n", msg.c_str());
+            if (channel == "ctrl-close")
+            {
+                Serial.println("Got message on ctrl-close: ending!");
+                redisInst->stopSubscribing();
+            }
+            else if (channel == "ctrl-add")
+            {
+                Serial.printf("Adding subscription to channel '%s'\n", msg.c_str());
 
-          if (!redisInst->unsubscribe(msg.c_str()))
-          {
-            Serial.println("Failed to remove subscription!");
-          }
-        }
-      },
-      [=](Redis* redisInst, RedisMessageError err) 
-      {
-        Serial.printf("Subscription error! '%d'\n", err);
-      }
-    );
+                if (!redisInst->subscribe(msg.c_str()))
+                {
+                    Serial.println("Failed to add subscription!");
+                }
+            }
+            else if (channel == "ctrl-rm")
+            {
+                Serial.printf("Removing subscription to channel '%s'\n", msg.c_str());
 
-    if (subRv) 
-    {
-      Serial.printf("Subscription setup failure: %d\n", subRv);
-    }
+                if (!redisInst->unsubscribe(msg.c_str()))
+                {
+                    Serial.println("Failed to remove subscription!");
+                }
+            }
+        },
+        [=](Redis *redisInst, RedisMessageError err) {
+            Serial.printf("Subscription error! '%d'\n", err);
+        });
 
-    Serial.println("Done!");
     redisConn.stop();
-    Serial.print("Connection closed!");
+    Serial.printf("Connection closed! (%d)\n", subRv);
+    return subRv == RedisSubscribeServerDisconnected; // server disconnect is retryable, everything else is fatal
 }
 
 void loop() {}


### PR DESCRIPTION
Adds appropriate check for disconnection in `RedisObject::parseType()`, and plumbs this event through to the consumer as a new `RedisSubscribeResult` value, specifically `RedisSubscribeServerDisconnected`. 

Re-factors & updates the `Subscribe` example to demonstrate proper handling of this return value using an exponential back-off re-connection loop.