### PR TITLE
fix: write json to `jsonStr` instead of `Serial`

### DIFF
--- a/examples/JsonPub/JsonPub.ino
+++ b/examples/JsonPub/JsonPub.ino
@@ -76,7 +76,7 @@ void loop()
         doc["uptime-ms"] = startTime;
 
         String jsonStr;
-        serializeJson(doc, Serial);
+        serializeJson(doc, jsonStr);
         Serial.printf("Sending JSON payload:\n\t'%s'\n", jsonStr.c_str());
 
         auto listeners = gRedis->publish("arduino-redis:jsonpub", jsonStr.c_str());


### PR DESCRIPTION
In the [JsonPub](https://github.com/electric-sheep-co/arduino-redis/blob/master/examples/JsonPub/JsonPub.ino) example, the serialised JSON output is written only to `Serial`, not to the previously declared `jsonStr`.

## previous output
### Serial
```
Connecting to the WiFi.........
IP Address: 192.168.1.146
{"analog":0,"wifi-rssi":-50,"uptime-ms":2803}Sending JSON payload:
	'' // <-- nothing in jsonStr
Published to 1 listeners
```
### Redis
```
1) "message"
2) "arduino-redis:jsonpub"
3) ""
```

## new/expected output
### Serial
```
Connecting to the WiFi.........
IP Address: 192.168.1.146
Sending JSON payload:
	'{"analog":0,"wifi-rssi":-57,"uptime-ms":2676}'
Published to 1 listeners
```
### Redis
```
1) "message"
2) "arduino-redis:jsonpub"
3) "{\"analog\":0,\"wifi-rssi\":-57,\"uptime-ms\":2676}"
```

@rpj 😀