### PR TITLE
Add non-blocking subscriber

### DIFF
--- a/Redis.cpp
+++ b/Redis.cpp
@@ -235,7 +235,7 @@ RedisSubscribeResult Redis::startSubscribingNonBlocking(RedisMsgCallback message
   {
     loopCallback();
     auto msg = RedisObject::parseTypeNonBlocking(conn);
-    if(msg == nullptr) {
+    if (msg == nullptr) {
       continue;
     }
 

--- a/Redis.cpp
+++ b/Redis.cpp
@@ -200,7 +200,7 @@ bool Redis::unsubscribe(const char *channelOrPattern)
   return false;
 }
 
-RedisSubscribeResult Redis::startSubscribing(RedisMsgCallback messageCallback, RedisMsgErrorCallback errCallback)
+RedisSubscribeResult Redis::startSubscribingNonBlocking(RedisMsgCallback messageCallback, LoopCallback loopCallback, RedisMsgErrorCallback errCallback)
 {
   if (!messageCallback)
   {
@@ -233,7 +233,11 @@ RedisSubscribeResult Redis::startSubscribing(RedisMsgCallback messageCallback, R
   subLoopRun = true;
   while (subLoopRun)
   {
-    auto msg = RedisObject::parseType(conn);
+    loopCallback();
+    auto msg = RedisObject::parseTypeNonBlocking(conn);
+    if(msg == nullptr) {
+      continue;
+    }
 
     if (msg->type() == RedisObject::Type::InternalError)
     {
@@ -273,4 +277,9 @@ RedisSubscribeResult Redis::startSubscribing(RedisMsgCallback messageCallback, R
   }
 
   return RedisSubscribeSuccess;
+}
+
+RedisSubscribeResult Redis::startSubscribing(RedisMsgCallback messageCallback, RedisMsgErrorCallback errCallback)
+{
+  return startSubscribingNonBlocking(messageCallback, []{}, errCallback);
 }

--- a/Redis.h
+++ b/Redis.h
@@ -74,6 +74,7 @@ class Redis
 public:
   /** Called upon successful receipt of a pub/sub `message` on subscribed `channel` */
   typedef void (*RedisMsgCallback)(Redis *, String channel, String message);
+  typedef void (*LoopCallback)();
   /** Called upon an error in the receipt of a pub/sub message */
   typedef void (*RedisMsgErrorCallback)(Redis *, RedisMessageError);
 
@@ -379,6 +380,7 @@ public:
    * the passed-in instance to end all further message processing.
    */
   RedisSubscribeResult startSubscribing(RedisMsgCallback messageCallback, RedisMsgErrorCallback errorCallback = nullptr);
+  RedisSubscribeResult startSubscribingNonBlocking(RedisMsgCallback messageCallback, LoopCallback loopCallback, RedisMsgErrorCallback errorCallback = nullptr);
 
   /**
    * Stops message processing on receipt of next message. Can be called from message handlers.

--- a/RedisInternal.cpp
+++ b/RedisInternal.cpp
@@ -135,7 +135,7 @@ static TypeParseMap g_TypeParseMap{
 
 std::shared_ptr<RedisObject> RedisObject::parseTypeNonBlocking(Client &client)
 {
-    if(client.connected() && !client.available()) {
+    if (client.connected() && !client.available()) {
         return nullptr;
     }
 
@@ -146,7 +146,7 @@ std::shared_ptr<RedisObject> RedisObject::parseTypeNonBlocking(Client &client)
     }
 
     typeChar = (RedisObject::Type)client.read();
-    if(typeChar == -1 || typeChar == '\r' || typeChar == '\n'){
+    if (typeChar == -1 || typeChar == '\r' || typeChar == '\n') {
         return nullptr;
     };
 
@@ -169,7 +169,7 @@ std::shared_ptr<RedisObject> RedisObject::parseTypeNonBlocking(Client &client)
 std::shared_ptr<RedisObject> RedisObject::parseType(Client &client)
 {
     std::shared_ptr<RedisObject> type = nullptr;
-    while(type==nullptr){
+    while (type==nullptr) {
         type = parseTypeNonBlocking(client);
     }
     return type;

--- a/RedisInternal.h
+++ b/RedisInternal.h
@@ -40,6 +40,7 @@ public:
 
     virtual ~RedisObject() {}
 
+    static std::shared_ptr<RedisObject> parseTypeNonBlocking(Client &);
     static std::shared_ptr<RedisObject> parseType(Client &);
 
     /** Initialize a RedisObject instance from the bytestream represented by 'client'.

--- a/examples/SubscribeNonBlocking/SubscribeNonBlocking.ino
+++ b/examples/SubscribeNonBlocking/SubscribeNonBlocking.ino
@@ -1,0 +1,132 @@
+#include <Redis.h>
+
+// this sketch will build for the ESP8266 or ESP32 platform
+#ifdef HAL_ESP32_HAL_H_ // ESP32
+#include <WiFiClient.h>
+#include <WiFi.h>
+#else
+#ifdef CORE_ESP8266_FEATURES_H // ESP8266
+#include <ESP8266WiFi.h>
+#endif
+#endif
+
+#define WIFI_SSID ""
+#define WIFI_PASSWORD ""
+
+#define REDIS_ADDR "0.0.0.0"
+#define REDIS_PORT 6379
+#define REDIS_PASSWORD "password"
+
+#define MAX_BACKOFF 300000 // 5 minutes
+
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println();
+
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    Serial.print("Connecting to the WiFi");
+    while (WiFi.status() != WL_CONNECTED)
+    {
+        delay(250);
+        Serial.print(".");
+    }
+    Serial.println();
+    Serial.print("IP Address: ");
+    Serial.println(WiFi.localIP());
+
+    auto backoffCounter = -1;
+    auto resetBackoffCounter = [&]() { backoffCounter = 0; };
+
+    resetBackoffCounter();
+    while (subscriberLoop(resetBackoffCounter))
+    {
+        auto curDelay = min((1000 * (int)pow(2, backoffCounter)), MAX_BACKOFF);
+
+        if (curDelay != MAX_BACKOFF)
+        {
+            ++backoffCounter;
+        }
+
+        Serial.printf("Waiting %lds to reconnect...\n", curDelay / 1000);
+        delay(curDelay);
+    }
+
+    Serial.printf("Done!\n");
+}
+
+// returning 'true' indicates the failure was retryable; false is fatal
+bool subscriberLoop(std::function<void(void)> resetBackoffCounter)
+{
+    WiFiClient redisConn;
+    if (!redisConn.connect(REDIS_ADDR, REDIS_PORT))
+    {
+        Serial.println("Failed to connect to the Redis server!");
+        return true;
+    }
+
+    Redis redis(redisConn);
+    auto connRet = redis.authenticate(REDIS_PASSWORD);
+    if (connRet == RedisSuccess)
+    {
+        Serial.println("Connected to the Redis server!");
+    }
+    else
+    {
+        Serial.printf("Failed to authenticate to the Redis server! Errno: %d\n", (int)connRet);
+        return false;
+    }
+
+    redis.subscribe("foo");
+    redis.subscribe("bar");
+
+    redis.psubscribe("ctrl-*");
+
+    Serial.println("Listening...");
+    resetBackoffCounter();
+
+    auto subRv = redis.startSubscribingNonBlocking(
+        [=](Redis *redisInst, String channel, String msg) {
+            Serial.printf("Message on channel '%s': \"%s\"\n", channel.c_str(), msg.c_str());
+
+            if (channel == "ctrl-close")
+            {
+                Serial.println("Got message on ctrl-close: ending!");
+                redisInst->stopSubscribing();
+            }
+            else if (channel == "ctrl-add")
+            {
+                Serial.printf("Adding subscription to channel '%s'\n", msg.c_str());
+
+                if (!redisInst->subscribe(msg.c_str()))
+                {
+                    Serial.println("Failed to add subscription!");
+                }
+            }
+            else if (channel == "ctrl-rm")
+            {
+                Serial.printf("Removing subscription to channel '%s'\n", msg.c_str());
+
+                if (!redisInst->unsubscribe(msg.c_str()))
+                {
+                    Serial.println("Failed to remove subscription!");
+                }
+            }
+        },
+        [=]() {
+            loop();
+        },
+        [=](Redis *redisInst, RedisMessageError err) {
+            Serial.printf("Subscription error! '%d'\n", err);
+        });
+
+    redisConn.stop();
+    Serial.printf("Connection closed! (%d)\n", subRv);
+    return subRv == RedisSubscribeServerDisconnected; // server disconnect is retryable, everything else is fatal
+}
+
+void loop() {
+    delay(1000);
+    Serial.println("loop");
+}


### PR DESCRIPTION
To be able to use the subscriber functionality of this library while doing some other non-blocking processing I created a new non-blocking subscriber function which takes a callback as additional parameter. This callback is called whenever the original subscriber would block/wait for messages coming in from Redis.