### PR TITLE
Add support for ACL authentication

### DIFF
--- a/Redis.cpp
+++ b/Redis.cpp
@@ -1,14 +1,15 @@
 #include "Redis.h"
 #include "RedisInternal.h"
 
-RedisReturnValue Redis::authenticate(const char *password)
+RedisReturnValue Redis::authenticate(const char *client, const char *password)
 {
   if (conn.connected())
   {
+    int clientLength = strlen(client);
     int passwordLength = strlen(password);
-    if (passwordLength > 0)
+    if (passwordLength > 0 && clientLength > 0)
     {
-      auto cmdRet = RedisCommand("AUTH", ArgList{password}).issue(conn);
+      auto cmdRet = RedisCommand("AUTH", ArgList{ client, password }).issue(conn);
       return cmdRet->type() == RedisObject::Type::SimpleString && (String)*cmdRet == "OK"
                  ? RedisSuccess
                  : RedisAuthFailure;
@@ -18,6 +19,11 @@ RedisReturnValue Redis::authenticate(const char *password)
   }
 
   return RedisNotConnectedFailure;
+}
+
+RedisReturnValue Redis::authenticate(const char *password)
+{
+  return authenticate("default", password);
 }
 
 #define TRCMD(t, c, ...) return RedisCommand(c, ArgList{__VA_ARGS__}).issue_typed<t>(conn)

--- a/Redis.h
+++ b/Redis.h
@@ -107,11 +107,18 @@ public:
   Redis &operator=(const Redis &&) = delete;
 
   /**
-   * Authenticate with the given password.
+   * Authenticate with the given password and client.
    * @param password The password with which to authenticate.
    * @returns RedisReturnValue detailing the result
    */
   RedisReturnValue authenticate(const char *password);
+  /**
+   * Authenticate with the given password.
+   * @param client The client with which to authenticate.
+   * @param password The password with which to authenticate.
+   * @returns RedisReturnValue detailing the result
+   */
+  RedisReturnValue authenticate(const char *client, const char *password);
 
   /**
    * Set `key` to `value`.


### PR DESCRIPTION
Redis 6.2 introduced the function of user ACL lists, which limit access and increase the level of system security: https://redis.io/docs/management/security/acl/

The changes in the fork were aimed only at adding support for this functionality.

In the first commit, an overload of the authenticate method was added to work with the new ACL, and the old method simply called: authenticate("default", password); which for new versions of Redis is identical to authenticate(password);

The second commit was caused by the fact that the old version, being the only (old) authentication method for requirepass, was no longer compatible with it. And I've added code duplication to maintain backward compatibility with Redis < 6.2